### PR TITLE
added hacky support for K65 on mac

### DIFF
--- a/src/ckb-daemon/usb.h
+++ b/src/ckb-daemon/usb.h
@@ -8,6 +8,8 @@
 #define V_CORSAIR       0x1b1c
 #define V_CORSAIR_STR   "1b1c"
 
+#define P_K65           0x1b17
+#define P_K65_STR       "1b17"
 #define P_K70           0x1b13
 #define P_K70_STR       "1b13"
 #define P_K70_NRGB      0x1b09

--- a/src/ckb-daemon/usb_mac.c
+++ b/src/ckb-daemon/usb_mac.c
@@ -121,7 +121,9 @@ void usbadd(void* context, IOReturn result, void* sender, IOHIDDeviceRef device)
     // Get the model and serial number
     long idproduct = usbgetvalue(device, CFSTR(kIOHIDProductIDKey));
     int model;
-    if(idproduct == P_K70)
+    if(idproduct == P_K65)
+      model = 65;
+    else if(idproduct == P_K70)
         model = 70;
     else if(idproduct == P_K95)
         model = 95;
@@ -236,8 +238,8 @@ void* threadrun(void* context){
     // Tell it which devices we want to look for
     CFMutableArrayRef devices = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
     if(devices){
-        int vendor = V_CORSAIR, product1 = P_K70, product2 = P_K95;
-        int products[] = { P_K70, P_K95 };
+        int vendor = V_CORSAIR, product0 = P_K65, product1 = P_K70, product2 = P_K95;
+        int products[] = { P_K65, P_K70, P_K95 };
         for(int i = 0; i < sizeof(products) / sizeof(int); i++){
             int product = products[i];
             CFMutableDictionaryRef device = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);


### PR DESCRIPTION
I'm extremely impressed that this worked - I have magic all over my K65 using my mac, congrats on the robust project.  I imagine there is a lot more to do to fully cover this (linux support seems a bit more complex), and there seems to have been quite a few bugs when the daemon was running.  Also the logging suggests there are checks that I didn't uncover:

$ ./ckb-daemon 
ckb Corsair Keyboard RGB driver v0.0.22
Setting FPS to 30
Setting default layout: gb
Root controller ready at /tmp/ckb0
Connecting Corsair K65 RGB Gaming Keyboard (S/N: 0203A03DAE3998A7534EDC40F5001940)
Warning: Got product ID 1b17 (expected 1b13)Device ready at /tmp/ckb1