### PR TITLE
(ckb-daemon) Use KEY_STOPCD rather than KEY_STOP as the media key code.

### DIFF
--- a/src/ckb-daemon/keymap.c
+++ b/src/ckb-daemon/keymap.c
@@ -102,7 +102,7 @@ const key keymap[N_KEYS_EXTENDED] = {
     { "right",      0x8b, KEY_RIGHT },
     { "lock",       0x08, KEY_CORSAIR },
     { "mute",       0x14, KEY_MUTE },
-    { "stop",       0x20, KEY_STOP },
+    { "stop",       0x20, KEY_STOPCD },
     { "prev",       0x2c, KEY_PREVIOUSSONG },
     { "play",       0x38, KEY_PLAYPAUSE },
     { "next",       0x44, KEY_NEXTSONG },

--- a/src/ckb-daemon/keymap_mac.h
+++ b/src/ckb-daemon/keymap_mac.h
@@ -132,7 +132,7 @@
 #define KEY_MUTE            (KEY_MEDIA + NX_KEYTYPE_MUTE)
 #define KEY_VOLUMEUP        (KEY_MEDIA + NX_KEYTYPE_SOUND_UP)
 #define KEY_VOLUMEDOWN      (KEY_MEDIA + NX_KEYTYPE_SOUND_DOWN)
-#define KEY_STOP            -1                                  // OSX has no stop key
+#define KEY_STOPCD          -1                                  // OSX has no stop key
 #define KEY_PREVIOUSSONG    (KEY_MEDIA + NX_KEYTYPE_PREVIOUS)
 #define KEY_PLAYPAUSE       (KEY_MEDIA + NX_KEYTYPE_PLAY)
 #define KEY_NEXTSONG        (KEY_MEDIA + NX_KEYTYPE_NEXT)


### PR DESCRIPTION
The code used so far (KEY_STOP) is not related to media controls, but is apparently a special function of Sun keyboards. Using KEY_STOPCD instead seems to be the right thing.