### PR TITLE
Support for Unity indicator and ordered color dithering

### DIFF
--- a/src/ckb-daemon/command.c
+++ b/src/ckb-daemon/command.c
@@ -15,6 +15,7 @@ static const char* const cmd_strings[CMD_COUNT - 1] = {
     "notifyon",
     "notifyoff",
     "fps",
+    "dither",
 
     "hwload",
     "hwsave",
@@ -167,6 +168,14 @@ int readcmd(usbdevice* kb, const char* line){
                 else if(delay > 10)
                     delay = 10;
                 kb->usbdelay = delay;
+            }
+            continue;
+        }
+        case DITHER: {
+            // 0: No dither, 1: Ordered dither.
+            uint dither;
+            if(sscanf(word, "%u", &dither) == 1 && dither >= 0 && dither <= 1){
+                kb->dither = dither;
             }
             continue;
         }

--- a/src/ckb-daemon/command.h
+++ b/src/ckb-daemon/command.h
@@ -6,14 +6,15 @@
 // Command operations
 typedef enum {
     // Special - handled by readcmd, no device functions
-    NONE        = -8,
-    MODE        = -7,   CMD_FIRST = MODE,
-    SWITCH      = -6,
-    LAYOUT      = -5,
-    ACCEL       = -4,
-    NOTIFYON    = -3,
-    NOTIFYOFF   = -2,
-    FPS         = -1,
+    NONE        = -9,
+    MODE        = -8,   CMD_FIRST = MODE,
+    SWITCH      = -7,
+    LAYOUT      = -6,
+    ACCEL       = -5,
+    NOTIFYON    = -4,
+    NOTIFYOFF   = -3,
+    FPS         = -2,
+    DITHER      = -1,
 
     // Hardware data
     HWLOAD      = 0,    CMD_VT_FIRST = 0,

--- a/src/ckb-daemon/led_keyboard.c
+++ b/src/ckb-daemon/led_keyboard.c
@@ -22,7 +22,7 @@ static uchar bit_reverse_table[256] = { O8(0) };
 static uchar ordered8to3(int index, uchar value){
     int m = value * 7;
     int b = m / 255;
-    if((m % 255) > bit_reverse_table[index])
+    if((m % 255) > bit_reverse_table[index & 0xff])
         b++;
     return b;
 }

--- a/src/ckb-daemon/led_keyboard.c
+++ b/src/ckb-daemon/led_keyboard.c
@@ -3,16 +3,45 @@
 #include "profile.h"
 #include "usb.h"
 
-static void makergb_512(const lighting* light, uchar data_pkt[5][MSG_SIZE]){
+// Define an ordered dithering table by using bit reversion.
+#define BR1(x) ((((x) & 0xaa) >> 1) | (((x) & 0x55) << 1))
+#define BR2(x) (((BR1(x) & 0xcc) >> 2) | ((BR1(x) & 0x33) << 2))
+#define BR4(x) (((BR2(x) & 0xf0) >> 4) | ((BR2(x) & 0x0f) << 4))
+#define O0(i) BR4(i),
+#define O1(i) O0(i) O0((i) + 1)
+#define O2(i) O1(i) O1((i) + 2)
+#define O3(i) O2(i) O2((i) + 4)
+#define O4(i) O3(i) O3((i) + 8)
+#define O5(i) O4(i) O4((i) + 16)
+#define O6(i) O5(i) O5((i) + 32)
+#define O7(i) O6(i) O6((i) + 64)
+#define O8(i) O7(i) O7((i) + 127)
+
+static uchar bit_reverse_table[256] = { O8(0) };
+
+static uchar ordered8to3(int index, uchar value){
+    int m = value * 7;
+    int b = m / 255;
+    if((m % 255) > bit_reverse_table[index])
+        b++;
+    return b;
+}
+
+static uchar quantize8to3(int index, uchar value){
+    return value >> 5;
+}
+
+static void makergb_512(const lighting* light, uchar data_pkt[5][MSG_SIZE],
+                        uchar (*ditherfn)(int, uchar)){
     uchar r[N_KEYS_KB / 2], g[N_KEYS_KB / 2], b[N_KEYS_KB / 2];
     // Compress RGB values to a 512-color palette
     for(int i = 0; i < N_KEYS_KB; i += 2){
-        char r1 = light->r[i], r2 = light->r[i + 1];
-        char g1 = light->g[i], g2 = light->g[i + 1];
-        char b1 = light->b[i], b2 = light->b[i + 1];
-        r[i / 2] = (7 - (r2 >> 5)) << 4 | (7 - (r1 >> 5));
-        g[i / 2] = (7 - (g2 >> 5)) << 4 | (7 - (g1 >> 5));
-        b[i / 2] = (7 - (b2 >> 5)) << 4 | (7 - (b1 >> 5));
+        char r1 = ditherfn(i, light->r[i]), r2 = ditherfn(i + 1, light->r[i + 1]);
+        char g1 = ditherfn(i, light->g[i]), g2 = ditherfn(i + 1, light->g[i + 1]);
+        char b1 = ditherfn(i, light->b[i]), b2 = ditherfn(i + 1, light->b[i + 1]);
+        r[i / 2] = (7 - r2) << 4 | (7 - r1);
+        g[i / 2] = (7 - g2) << 4 | (7 - g1);
+        b[i / 2] = (7 - b2) << 4 | (7 - b1);
     }
     memcpy(data_pkt[0] + 4, r, 60);
     memcpy(data_pkt[1] + 4, r + 60, 12);
@@ -85,7 +114,7 @@ int updatergb_kb(usbdevice* kb, int force){
             { 0x7f, 0x04, 36, 0 },
             { 0x07, 0x27, 0x00, 0x00, 0xD8 }
         };
-        makergb_512(newlight, data_pkt);
+        makergb_512(newlight, data_pkt, kb->dither ? ordered8to3 : quantize8to3);
         if(!usbsend(kb, data_pkt[0], 5))
             return -1;
     //}
@@ -124,7 +153,7 @@ int savergb_kb(usbdevice* kb, lighting* light, int mode){
             { 0x7f, 0x04, 36, 0 },
             { 0x07, 0x14, 0x02, 0x00, 0x01, mode + 1 }
         };
-        makergb_512(light, data_pkt);
+        makergb_512(light, data_pkt, kb->dither ? ordered8to3 : quantize8to3);
         if(!usbsend(kb, data_pkt[0], 5))
             return -1;
     }

--- a/src/ckb-daemon/structures.h
+++ b/src/ckb-daemon/structures.h
@@ -222,6 +222,8 @@ typedef struct {
     usbinput input;
     // Indicator LED state
     uchar ileds;
+    // Color dithering in use
+    char dither;
 } usbdevice;
 
 #endif  // STRUCTURES_H

--- a/src/ckb/ckb.pro
+++ b/src/ckb/ckb.pro
@@ -35,6 +35,13 @@ DEFINES += CKB_VERSION_STR="\\\"$$CKB_VERSION_STR\\\""
 LIBS += -lz
 DEFINES += QUAZIP_STATIC
 
+# Conditionally use libappindicator to support Unity indicators
+system(pkg-config --exists appindicator-0.1) {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += appindicator-0.1
+    DEFINES += USE_LIBAPPINDICATOR
+}
+
 SOURCES += main.cpp\
         mainwindow.cpp \
     kbwidget.cpp \

--- a/src/ckb/kb.h
+++ b/src/ckb/kb.h
@@ -39,6 +39,10 @@ public:
     static inline int   frameRate()                     { return _frameRate; }
     static void         frameRate(int newFrameRate);
 
+    // Whether dithering is used
+    inline bool  dither()                        { return _dither; }
+    void         dither(bool newDither);
+
     // Profile saved to hardware
     inline KbProfile*   hwProfile() { return _hwProfile; }
     void                hwProfile(KbProfile* newHwProfile);
@@ -109,12 +113,15 @@ private slots:
 
 private:
     static int _frameRate;
+
     KbProfile*          _currentProfile;
     QList<KbProfile*>   _profiles;
     KbMode*             _currentMode;
 
     KeyMap::Model   _model;
     KeyMap::Layout  _layout;
+
+    bool _dither;
 
     // Current firmware update file
     QString fwUpdPath;

--- a/src/ckb/kbwidget.cpp
+++ b/src/ckb/kbwidget.cpp
@@ -317,6 +317,7 @@ void KbWidget::devUpdate(){
     ui->fwLabel->setText(device->firmware);
     ui->pollLabel->setText(device->pollrate);
     ui->layoutBox->setCurrentIndex(device->layout());
+    ui->ditherCheck->setChecked(device->dither());
 }
 
 void KbWidget::modeUpdate(){
@@ -363,6 +364,11 @@ void KbWidget::on_inactiveSwitchBox_activated(int index){
 void KbWidget::on_muteCheck_clicked(bool checked){
     if(ui->inactiveSwitchCheck->isCheckable())
         currentMode->light()->showMute(checked);
+}
+
+void KbWidget::on_ditherCheck_clicked(bool checked){
+    if(ui->ditherCheck->isCheckable())
+        device->dither(checked);
 }
 
 void KbWidget::on_layoutBox_activated(int index){

--- a/src/ckb/kbwidget.h
+++ b/src/ckb/kbwidget.h
@@ -78,6 +78,7 @@ private slots:
     void on_inactiveSwitchCheck_clicked(bool checked);
     void on_inactiveSwitchBox_activated(int index);
     void on_muteCheck_clicked(bool checked);
+    void on_ditherCheck_clicked(bool checked);
     void on_layoutBox_activated(int index);
     void on_tabWidget_currentChanged(int index);
     void on_fwUpdButton_clicked();

--- a/src/ckb/kbwidget.ui
+++ b/src/ckb/kbwidget.ui
@@ -51,7 +51,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="lightTab">
       <attribute name="title">
@@ -247,6 +247,37 @@
           <widget class="QCheckBox" name="muteCheck">
            <property name="text">
             <string>Show mute indicator</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Colors</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout_6">
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="ditherCheck">
+           <property name="text">
+            <string>Use spacial dithering to simulate extra color resolution</string>
            </property>
           </widget>
          </item>

--- a/src/ckb/mainwindow.cpp
+++ b/src/ckb/mainwindow.cpp
@@ -2,6 +2,7 @@
 #include "kbfirmware.h"
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include <cstdlib>
 #include <QSharedMemory>
 #include <QShortcut>
 #include <QMessageBox>
@@ -24,6 +25,22 @@ QString devpath = "/var/run/ckb%1";
 QTimer* eventTimer = 0;
 MainWindow* MainWindow::mainWindow = 0;
 
+#ifdef USE_LIBAPPINDICATOR
+extern "C" {
+    void quitIndicator(GtkMenu* menu, gpointer data) {
+        Q_UNUSED(menu);
+        MainWindow* window = static_cast<MainWindow*>(data);
+        window->quitApp();
+    }
+
+    void restoreIndicator(GtkMenu* menu, gpointer data) {
+        Q_UNUSED(menu);
+        MainWindow* window = static_cast<MainWindow*>(data);
+        window->showWindow();
+    }
+}
+#endif // USE_LIBAPPINDICATOR
+
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow)
@@ -31,15 +48,47 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     mainWindow = this;
 
-    trayIconMenu = new QMenu(this);
     restoreAction = new QAction(tr("Restore"), this);
     closeAction = new QAction(tr("Quit ckb"), this);
-    trayIconMenu->addAction(restoreAction);
-    trayIconMenu->addAction(closeAction);
-    trayIcon = new QSystemTrayIcon(QIcon(":/img/ckb-logo.png"), this);
-    trayIcon->setContextMenu(trayIconMenu);
-    if(!CkbSettings::get("Program/SuppressTrayIcon").toBool())
-        trayIcon->show();
+
+#ifdef USE_LIBAPPINDICATOR
+    QString desktop = std::getenv("XDG_CURRENT_DESKTOP");
+    unityDesktop = (desktop.toLower() == "unity");
+
+    if(unityDesktop){
+        trayIcon = 0;
+
+        indicatorMenu = gtk_menu_new();
+        indicatorMenuRestoreItem = gtk_menu_item_new_with_label("Restore");
+        indicatorMenuQuitItem = gtk_menu_item_new_with_label("Quit ckb");
+
+        gtk_menu_shell_append(GTK_MENU_SHELL(indicatorMenu), indicatorMenuRestoreItem);
+        gtk_menu_shell_append(GTK_MENU_SHELL(indicatorMenu), indicatorMenuQuitItem);
+
+        g_signal_connect(indicatorMenuQuitItem, "activate",
+            G_CALLBACK(quitIndicator), this);
+        g_signal_connect(indicatorMenuRestoreItem, "activate",
+            G_CALLBACK(restoreIndicator), this);
+
+        gtk_widget_show(indicatorMenuRestoreItem);
+        gtk_widget_show(indicatorMenuQuitItem);
+
+        indicator = app_indicator_new("ckb", "indicator-messages", APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+
+        app_indicator_set_status(indicator, APP_INDICATOR_STATUS_ACTIVE);
+        app_indicator_set_menu(indicator, GTK_MENU(indicatorMenu));
+        app_indicator_set_icon(indicator, "ckb");
+    } else
+#endif // USE_LIBAPPINDICATOR
+    {
+        trayIconMenu = new QMenu(this);
+        trayIconMenu->addAction(restoreAction);
+        trayIconMenu->addAction(closeAction);
+        trayIcon = new QSystemTrayIcon(QIcon(":/img/ckb-logo.png"), this);
+        trayIcon->setContextMenu(trayIconMenu);
+        connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(iconClicked(QSystemTrayIcon::ActivationReason)));
+     }
+     toggleTrayIcon(!CkbSettings::get("Program/SuppressTrayIcon").toBool());
 
 #ifdef Q_OS_MACX
     // Make a custom "Close" menu action for OSX, as the default one brings up the "still running" popup unnecessarily
@@ -54,7 +103,6 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->actionExit, SIGNAL(triggered()), this, SLOT(quitApp()));
     connect(closeAction, SIGNAL(triggered()), this, SLOT(quitApp()));
     connect(restoreAction, SIGNAL(triggered()), this, SLOT(showWindow()));
-    connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(iconClicked(QSystemTrayIcon::ActivationReason)));
 
     connect(qApp, SIGNAL(aboutToQuit()), this, SLOT(cleanup()));
 
@@ -68,6 +116,15 @@ MainWindow::MainWindow(QWidget *parent) :
 
     ckbGuiVersion = PARSE_CKB_VERSION(CKB_VERSION_STR);
     scanKeyboards();
+}
+
+void MainWindow::toggleTrayIcon(bool visible) {
+#ifdef USE_LIBAPPINDICATOR
+    if(unityDesktop)
+        app_indicator_set_status(indicator, visible ? APP_INDICATOR_STATUS_ACTIVE : APP_INDICATOR_STATUS_PASSIVE);
+    else
+#endif // USE_LIBAPPINDICATOR
+        trayIcon->setVisible(visible);
 }
 
 void MainWindow::scanKeyboards(){

--- a/src/ckb/mainwindow.h
+++ b/src/ckb/mainwindow.h
@@ -9,6 +9,17 @@
 #include "kbwidget.h"
 #include "settingswidget.h"
 
+#ifdef USE_LIBAPPINDICATOR
+#define signals_BACKUP signals
+#undef signals
+extern "C" {
+  #include <libappindicator/app-indicator.h>
+  #include <gtk/gtk.h>
+}
+#define signals signals_BACKUP
+#undef signals_BACKUP
+#endif // USE_LIBAPPINDICATOR
+
 // ckb version info (populated at load)
 extern float ckbGuiVersion;
 extern float ckbDaemonVersion;
@@ -39,6 +50,7 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
+    void toggleTrayIcon(bool visible);
     void scanKeyboards();
     SettingsWidget* settingsWidget;
     QList<KbWidget*> kbWidgets;
@@ -46,6 +58,13 @@ public:
     QAction* restoreAction;
     QAction* closeAction;
 
+#ifdef USE_LIBAPPINDICATOR
+    bool                unityDesktop;
+    AppIndicator*       indicator;
+    GtkWidget*          indicatorMenu;
+    GtkWidget*          indicatorMenuQuitItem;
+    GtkWidget*          indicatorMenuRestoreItem;
+#endif // USE_LIBAPPINDICATOR
     QMenu*              trayIconMenu;
     QSystemTrayIcon*    trayIcon;
 
@@ -53,11 +72,13 @@ public:
 
     static MainWindow* mainWindow;
 
+public slots:
+    void showWindow();
+    void quitApp();
+
 private slots:
     void timerTick();
     void iconClicked(QSystemTrayIcon::ActivationReason reason);
-    void showWindow();
-    void quitApp();
     void cleanup();
     void showFwUpdateNotification(QWidget* widget, float version);
 

--- a/src/ckb/settingswidget.cpp
+++ b/src/ckb/settingswidget.cpp
@@ -210,7 +210,7 @@ void SettingsWidget::on_autoFWBox_clicked(bool checked){
 
 void SettingsWidget::on_trayBox_clicked(bool checked){
     CkbSettings::set("Program/SuppressTrayIcon", !checked);
-    MainWindow::mainWindow->trayIcon->setVisible(checked);
+    MainWindow::mainWindow->toggleTrayIcon(checked);
 }
 
 void SettingsWidget::on_loginItemBox_clicked(bool checked){


### PR DESCRIPTION
Two pieces of work in this pull request:

 * Add support for libappindicator as an optional dependency to use an indicator rather than QSystemTrayIcon under Unity. This fixes the current issue with the QT icon showing at a wrong place. By reading https://bugreports.qt.io/browse/QTBUG-31762 it looks like this will be eventually fixed in QT 5.5.0, so perhaps this change can be reverted in the future.

 * Add an option to use ordered dithering to "simulate" more than 512 across several keys. What it does is actually making different keys change at different times during a smooth transition, trying to take advantage of inter-key light leaks. Its effect can be observed by turning the feature on and off while the demo "breathing" mode is running.