### PR TITLE
Install icons via xdg-utils and revert icon temp file. Document dither command in daemon.

### DIFF
--- a/DAEMON.md
+++ b/DAEMON.md
@@ -84,6 +84,8 @@ Additionally, multiple commands may be combined into one, for instance:
 
 By default, the controller runs at 30 FPS, meaning that attempts to animate the LEDs faster than that will be ignored. If you wish to change it, send the command `fps <n>`. The maximum frame rate is 60.
 
+For devices running in 512-color mode, color dithering can be enabled by sending the command `dither 1`. The command `dither 0` disables dithering.
+
 Indicators
 ----------
 

--- a/quickinstall
+++ b/quickinstall
@@ -67,6 +67,12 @@ fi
 shopt -s nocasematch
 read -rp "Install ckb system-wide [Y/n]? " doinstall
 if [[ $doinstall =~ no? ]]; then
+    # Install icon and .desktop locally
+    echo "Installing icon and application launcher for the local user..."
+    xdg-icon-resource install --novendor --size 512 usr/ckb.png 2>$TMPFILE
+    checkfail $?
+    xdg-desktop-menu install --novendor usr/ckb.desktop 2>$TMPFILE
+    checkfail $?
     echo "ckb will not be installed system-wide or run as a service."
     echo "Re-run this script if you change your mind."
     finish 0
@@ -99,14 +105,10 @@ else
     checkfail $?
     sudo install bin/ckb-animations/* $PREFIX/ckb-animations 2>$TMPFILE
     checkfail $?
-    # Install .desktop and icon
-    sudo mkdir -p /usr/share/applications 2>$TMPFILE
+    # Install icon and .desktop
+    sudo xdg-icon-resource install --novendor --size 512 usr/ckb.png 2>$TMPFILE
     checkfail $?
-    sudo install usr/ckb.desktop /usr/share/applications/ckb.desktop 2>$TMPFILE
-    checkfail $?
-    sudo mkdir -p /usr/share/icons/hicolor/512x512/apps 2>$TMPFILE
-    checkfail $?
-    sudo install usr/ckb.png /usr/share/icons/hicolor/512x512/apps/ckb.png 2>$TMPFILE
+    sudo xdg-desktop-menu install --novendor usr/ckb.desktop 2>$TMPFILE
     checkfail $?
     echo "Installed in $PREFIX"
 fi

--- a/src/ckb/mainwindow.cpp
+++ b/src/ckb/mainwindow.cpp
@@ -76,20 +76,9 @@ MainWindow::MainWindow(QWidget *parent) :
 
         indicator = app_indicator_new("ckb", "indicator-messages", APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
 
-        // Write app icon to temporary file
-        QString path = iconPath = QDir::temp().absoluteFilePath("ckb.png");
-        if(!QFile::copy(":/img/ckb-logo.png", iconPath)){
-            // Fall back to preset path
-            path = "/usr/share/icons/hicolor/512x512/apps/ckb.png";
-            iconPath = "";
-            if(!QFile::exists(path))
-                path = "ckb";
-        }
-        QByteArray cPath = path.toUtf8();
-
         app_indicator_set_status(indicator, APP_INDICATOR_STATUS_ACTIVE);
         app_indicator_set_menu(indicator, GTK_MENU(indicatorMenu));
-        app_indicator_set_icon(indicator, cPath.constData());
+        app_indicator_set_icon(indicator, "ckb");
     } else
 #endif // USE_LIBAPPINDICATOR
     {
@@ -334,11 +323,6 @@ void MainWindow::cleanup(){
         delete w;
     kbWidgets.clear();
     CkbSettings::cleanUp();
-#ifdef USE_LIBAPPINDICATOR
-    // Remove temporary icon file
-    if(!iconPath.isEmpty())
-        QFile::remove(iconPath);
-#endif  // USE_LIBAPPINDICATOR
 }
 
 MainWindow::~MainWindow(){

--- a/src/ckb/mainwindow.h
+++ b/src/ckb/mainwindow.h
@@ -64,7 +64,6 @@ public:
     GtkWidget*          indicatorMenu;
     GtkWidget*          indicatorMenuQuitItem;
     GtkWidget*          indicatorMenuRestoreItem;
-    QString             iconPath;
 #endif // USE_LIBAPPINDICATOR
     QMenu*              trayIconMenu;
     QSystemTrayIcon*    trayIcon;

--- a/usr/ckb.desktop
+++ b/usr/ckb.desktop
@@ -5,4 +5,4 @@ Type=Application
 Name=ckb
 Comment=Corsair keyboard driver user interface
 Exec=ckb
-Icon=/usr/share/icons/hicolor/512x512/apps/ckb.png
+Icon=ckb


### PR DESCRIPTION
Hi there. Two changes in this pull request:

 * Revert writing the indicator icon to a temp file; instead install the icon and the .desktop file using xdg-utils as discussed in https://github.com/ccMSC/ckb/pull/79

 * Add missing documentation for the daemon dither command.