### PR TITLE
Mac OS X Support

### DIFF
--- a/src/ckb-daemon/ckb-daemon.pro
+++ b/src/ckb-daemon/ckb-daemon.pro
@@ -14,7 +14,7 @@ macx {
 }
 
 QMAKE_CFLAGS  = -std=gnu99 -Wno-unused-parameter -Werror=all
-QMAKE_MAC_SDK = macosx10.10
+QMAKE_MAC_SDK = macosx10.11
 
 # Minimal build - remove Qt defaults
 CONFIG   = debug_and_release

--- a/src/ckb-daemon/usb_mac.c
+++ b/src/ckb-daemon/usb_mac.c
@@ -400,7 +400,7 @@ int usbmain(){
     int vendor = V_CORSAIR;
     int products[] = {
         // Keyboards
-        P_K65, P_K70, P_K70_NRGB, P_K95, P_K95_NRGB, P_STRAFE, P_STRAFE_NRGB
+        P_K65, P_K70, P_K70_NRGB, P_K95, P_K95_NRGB, P_STRAFE, P_STRAFE_NRGB,
         // Mice
         P_M65, P_SABRE, P_SCIMITAR
     };

--- a/src/ckb-gradient/ckb-gradient.pro
+++ b/src/ckb-gradient/ckb-gradient.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-gradient
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MAC_SDK = macosx10.10
+QMAKE_MAC_SDK = macosx10.11
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations

--- a/src/ckb-pinwheel/ckb-pinwheel.pro
+++ b/src/ckb-pinwheel/ckb-pinwheel.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-pinwheel
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MAC_SDK = macosx10.10
+QMAKE_MAC_SDK = macosx10.11
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations

--- a/src/ckb-rain/ckb-rain.pro
+++ b/src/ckb-rain/ckb-rain.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-rain
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MAC_SDK = macosx10.10
+QMAKE_MAC_SDK = macosx10.11
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations

--- a/src/ckb-random/ckb-random.pro
+++ b/src/ckb-random/ckb-random.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-random
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MAC_SDK = macosx10.10
+QMAKE_MAC_SDK = macosx10.11
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations

--- a/src/ckb-ripple/ckb-ripple.pro
+++ b/src/ckb-ripple/ckb-ripple.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-ripple
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MAC_SDK = macosx10.10
+QMAKE_MAC_SDK = macosx10.11
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations

--- a/src/ckb-wave/ckb-wave.pro
+++ b/src/ckb-wave/ckb-wave.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-wave
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MAC_SDK = macosx10.10
+QMAKE_MAC_SDK = macosx10.11
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations

--- a/src/ckb/ckb.pro
+++ b/src/ckb/ckb.pro
@@ -19,7 +19,8 @@ macx {
 }
 
 # OSX settings
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+QMAKE_MAC_SDK = macosx10.11
+QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
 ICON = ckb-logo.icns
 QMAKE_INFO_PLIST = ckb-info.plist
 macx {


### PR DESCRIPTION
This pull request fixes a missing comma in a statement in usb_mac.c, presumably just a copy-paste error, and updates the OS X build target files so that they will build correctly on OS X El Capitan.

PS: Thanks so much for working on this!  I just got an RGB Strafe, and it's rainbowing happily under my fingers as I type this.