### PR TITLE
Some minor changes to solve problems concerning "macro" Statements se…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Makefile.*
 moc_*
 ui_*
 qrc_*
+ckb.kdev4

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-beta-v0.2.2
+alpha-v0.2.2-LE1

--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,8 @@
+#!/bin/bash
+sudo systemctl stop ckb-daemon
+sudo rm -f /usr/lib/systemd/system/ckb-daemon.service
+sudo rm -f /usr/bin/ckb /usr/bin/ckb-daemon /usr/share/applications/ckb.desktop /usr/share/icons/hicolor/512x512/apps/ckb.png
+sudo rm -rf /usr/bin/ckb-animations
+make clean
+rm -fv Makefile Makefile.* */*/Makefile */*/Makefile.*
+exit 0

--- a/src/ckb-daemon/device_vtable.c
+++ b/src/ckb-daemon/device_vtable.c
@@ -49,6 +49,7 @@ const devcmd vtable_keyboard = {
     .bind = cmd_bind,
     .unbind = cmd_unbind,
     .rebind = cmd_rebind,
+    .macro = cmd_macro,
 
     .dpi = cmd_macro_none,
     .dpisel = cmd_none,

--- a/src/ckb-daemon/input.c
+++ b/src/ckb-daemon/input.c
@@ -313,7 +313,7 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment){
         bind->macros = realloc(bind->macros, (bind->macrocap += 16) * sizeof(keymacro));
 }
 
-void cmd_macro(usbdevice* kb, usbmode* mode, const char* keys, const char* assignment){
+void cmd_macro(usbdevice* kb, usbmode* mode, const int notifynumber, const char* keys, const char* assignment){
     pthread_mutex_lock(imutex(kb));
     _cmd_macro(mode, keys, assignment);
     pthread_mutex_unlock(imutex(kb));

--- a/src/ckb-daemon/input.h
+++ b/src/ckb-daemon/input.h
@@ -27,7 +27,7 @@ void cmd_unbind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const cha
 // Resets a key binding
 void cmd_rebind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const char* ignored);
 // Creates or updates a macro. Pass null strings to clear all macros
-void cmd_macro(usbdevice* kb, usbmode* mode, const char* keys, const char* assignment);
+void cmd_macro(usbdevice* kb, usbmode* mode, const int notifynumber, const char* keys, const char* assignment);
 
 #ifdef OS_LINUX
 // Is a key a modifier?


### PR DESCRIPTION
…nt to cmd-pipe.

- added cmd_macro in call structure
- added parameter notifynumber in call hierarchy

runs on linux mint 17.2

Tested with:
  echo "macro clear" > /dev/input/ckb1/cmd
  echo "bind g1:a g2:b g3:x" > /dev/input/ckb1/cmd
  echo "macro clear" > /dev/input/ckb1/cmd
  echo "macro g1:+a,-a,+f,-f,+o,-o,+o,-o,+b,-b,+a,-a,+r,-r,+enter,-enter" > /dev/input/ckb1/cmd
   Keyboard sends --> afoobar
  echo "macro clear" > /dev/input/ckb1/cmd