### PR TITLE
Bugfix: string param signal

### DIFF
--- a/src/ckb/animsettingdialog.cpp
+++ b/src/ckb/animsettingdialog.cpp
@@ -139,7 +139,7 @@ AnimSettingDialog::AnimSettingDialog(QWidget* parent, KbAnim* anim) :
             widget = new QLineEdit(this);
             ((QLineEdit*)widget)->setText(value.toString());
             colSpan = 3;
-            connect(widget, SIGNAL(textEdit(const QString&)), &updateMapper, SLOT(map()));
+            connect(widget, SIGNAL(textEdited(const QString&)), &updateMapper, SLOT(map()));
             break;
         case AnimScript::Param::LABEL:
             widget = new QLabel(this);


### PR DESCRIPTION
The signal name appears to be "textEdited', not 'textEdit'.  I needed this change for string parameters to ckb animations to save a new value.

Steps to reproduce:
- Create a ckb animation that takes a *string* parameter, and provide a default value
- In ckb UI, use 'Edit properties' to change the string parameter value to something new, and click OK
- Click on 'Edit properties'; you will find that the string parameter value retains its original value.
