### PR TITLE
Some minor changes to solve problems concerning "macro" Statements…

### DIFF
--- a/src/ckb-daemon/device_vtable.c
+++ b/src/ckb-daemon/device_vtable.c
@@ -49,6 +49,7 @@ const devcmd vtable_keyboard = {
     .bind = cmd_bind,
     .unbind = cmd_unbind,
     .rebind = cmd_rebind,
+    .macro = cmd_macro,
 
     .dpi = cmd_macro_none,
     .dpisel = cmd_none,

--- a/src/ckb-daemon/input.c
+++ b/src/ckb-daemon/input.c
@@ -313,7 +313,7 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment){
         bind->macros = realloc(bind->macros, (bind->macrocap += 16) * sizeof(keymacro));
 }
 
-void cmd_macro(usbdevice* kb, usbmode* mode, const char* keys, const char* assignment){
+void cmd_macro(usbdevice* kb, usbmode* mode, const int notifynumber, const char* keys, const char* assignment){
     pthread_mutex_lock(imutex(kb));
     _cmd_macro(mode, keys, assignment);
     pthread_mutex_unlock(imutex(kb));

--- a/src/ckb-daemon/input.h
+++ b/src/ckb-daemon/input.h
@@ -27,7 +27,7 @@ void cmd_unbind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const cha
 // Resets a key binding
 void cmd_rebind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const char* ignored);
 // Creates or updates a macro. Pass null strings to clear all macros
-void cmd_macro(usbdevice* kb, usbmode* mode, const char* keys, const char* assignment);
+void cmd_macro(usbdevice* kb, usbmode* mode, const int notifynumber, const char* keys, const char* assignment);
 
 #ifdef OS_LINUX
 // Is a key a modifier?


### PR DESCRIPTION
…sent to cmd-pipe.

- added cmd_macro in call structure
- added parameter notifynumber in call hierarchy

runs on linux mint 17.2

Tested with:
  echo "macro clear" > /dev/input/ckb1/cmd
  echo "bind g1:a g2:b g3:x" > /dev/input/ckb1/cmd
  echo "macro clear" > /dev/input/ckb1/cmd
  echo "macro g1:+a,-a,+f,-f,+o,-o,+o,-o,+b,-b,+a,-a,+r,-r,+enter,-enter" > /dev/input/ckb1/cmd
   --> afoobar
  echo "macro clear" > /dev/input/ckb1/ckb