### PR TITLE
Add brew installed qt5 path to qmake-auto script

### DIFF
--- a/qmake-auto
+++ b/qmake-auto
@@ -11,7 +11,7 @@ if [[ "$QMAKE" != "" ]]; then
 fi
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # OSX: Look for qmake in standard install locations
-    QMAKE=`find ~/Qt/*/clang_64/bin ~/Qt5*/*/clang_64/bin ~/Applications/Qt/*/clang_64/bin ~/Applications/Qt5*/*/clang_64/bin /Applications/Qt/*/clang_64/bin /Applications/Qt5*/*/clang_64/bin -name qmake -print -quit 2>/dev/null`
+    QMAKE=`find /usr/local/opt/qt5/bin ~/Qt/*/clang_64/bin ~/Qt5*/*/clang_64/bin ~/Applications/Qt/*/clang_64/bin ~/Applications/Qt5*/*/clang_64/bin /Applications/Qt/*/clang_64/bin /Applications/Qt5*/*/clang_64/bin -name qmake -print -quit 2>/dev/null`
     [[ $QMAKE == "" ]] && die
 else
     # Linux: Look for system-installed Qt5


### PR DESCRIPTION
This will search through the qt install directory created when `brew install qt5` has been run.
