### PR TITLE
Use rm -f instead of rm for deleting makefiles

### DIFF
--- a/quickinstall
+++ b/quickinstall
@@ -44,7 +44,7 @@ if [[ -d $SRCDIR ]]; then
     echo "Preparing build files..."
     # Clean first
     make clean >/dev/null 2>&1
-    rm Makefile Makefile.* */*/Makefile */*/Makefile.* >/dev/null 2>&1
+    rm -f Makefile Makefile.* */*/Makefile */*/Makefile.* >/dev/null 2>&1
     # Generate makefiles
     ./qmake-auto $QMAKEFLAGS > $TMPFILE 2>&1
     checkfail $?


### PR DESCRIPTION
On systems where rm isn't aliased to rm -f, this avoids the installer from suspending forever while waiting for the user to confirm.