### PR TITLE
Add support for Sabre with 0x1b32 PID

### DIFF
--- a/src/ckb-daemon/usb.c
+++ b/src/ckb-daemon/usb.c
@@ -34,7 +34,7 @@ const char* product_str(short product){
         return "strafe";
     if(product == P_M65)
         return "m65";
-    if(product == P_SABRE_O || product == P_SABRE_L)
+    if(product == P_SABRE_O || product == P_SABRE_L || product == P_SABRE_O2)
         return "sabre";
     if(product == P_SCIMITAR)
         return "scimitar";

--- a/src/ckb-daemon/usb.h
+++ b/src/ckb-daemon/usb.h
@@ -36,9 +36,11 @@
 
 #define P_SABRE_O       0x1b14
 #define P_SABRE_O_STR   "1b14"
+#define P_SABRE_O2   0x1b32 /* Observed on a CH-9000111-EU model SABRE */
+#define P_SABRE_O2_STR "1b32"
 #define P_SABRE_L       0x1b19
 #define P_SABRE_L_STR   "1b19"
-#define IS_SABRE(kb)    ((kb)->vendor == V_CORSAIR && ((kb)->product == P_SABRE_O || (kb)->product == P_SABRE_L))
+#define IS_SABRE(kb)    ((kb)->vendor == V_CORSAIR && ((kb)->product == P_SABRE_O || (kb)->product == P_SABRE_L || (kb)->product == P_SABRE_O2))
 
 #define P_SCIMITAR      0x1b1e
 #define P_SCIMITAR_STR  "1b1e"
@@ -61,7 +63,7 @@ const char* product_str(short product);
 #define IS_MONOCHROME_DEV(kb)           IS_MONOCHROME((kb)->vendor, (kb)->product)
 
 // Mouse vs keyboard test
-#define IS_MOUSE(vendor, product)       ((vendor) == (V_CORSAIR) && ((product) == (P_M65) || (product) == (P_SABRE_O) || (product) == (P_SABRE_L) || (product) == (P_SCIMITAR)))
+#define IS_MOUSE(vendor, product)       ((vendor) == (V_CORSAIR) && ((product) == (P_M65) || (product) == (P_SABRE_O) || (product) == (P_SABRE_L) || (product) == (P_SCIMITAR) || (product) == (P_SABRE_O2)))
 #define IS_MOUSE_DEV(kb)                IS_MOUSE((kb)->vendor, (kb)->product)
 
 // USB delays for when the keyboards get picky about timing

--- a/src/ckb-daemon/usb_linux.c
+++ b/src/ckb-daemon/usb_linux.c
@@ -363,7 +363,8 @@ static _model models[] = {
     { P_M65_STR, P_M65 },
     { P_SABRE_O_STR, P_SABRE_O },
     { P_SABRE_L_STR, P_SABRE_L },
-    { P_SCIMITAR_STR, P_SCIMITAR }
+    { P_SCIMITAR_STR, P_SCIMITAR },
+    { P_SABRE_O2_STR, P_SABRE_O2 }
 };
 #define N_MODELS (sizeof(models) / sizeof(_model))
 

--- a/src/ckb-daemon/usb_mac.c
+++ b/src/ckb-daemon/usb_mac.c
@@ -772,7 +772,7 @@ int usbmain(){
         // Keyboards
         P_K65, P_K70, P_K70_NRGB, P_K95, P_K95_NRGB, P_STRAFE, P_STRAFE_NRGB,
         // Mice
-        P_M65, P_SABRE_O, P_SABRE_L, P_SCIMITAR
+        P_M65, P_SABRE_O, P_SABRE_L, P_SCIMITAR, P_SABRE_O2
     };
 
     // Setup global variables

--- a/src/ckb/fwupgradedialog.cpp
+++ b/src/ckb/fwupgradedialog.cpp
@@ -20,7 +20,9 @@ static KbId ids[] = {
     { 0x1b1c, 0x1b20, "corsair strafe rgb" },
     // Mice
     { 0x1b1c, 0x1b12, "corsair m65 rgb" },
-    { 0x1b1c, 0x1b1e, "corsair scimitar rgb" }
+    { 0x1b1c, 0x1b1e, "corsair scimitar rgb" },
+    //SABRE CH-9000111-EU
+    { 0x1b1c, 0x1b32, "corsair sabre optical rgb" }
 };
 
 static const int DIALOG_WIDTH = 420;


### PR DESCRIPTION
Added support for another sabre optical RGB variant, mine is a CH-9000111-EU.