### PR TITLE
Initial support for K70 LUX (non-RGB) 0x1b36

### DIFF
--- a/src/ckb-daemon/usb.c
+++ b/src/ckb-daemon/usb.c
@@ -26,7 +26,7 @@ const char* vendor_str(short vendor){
 const char* product_str(short product){
     if(product == P_K95 || product == P_K95_NRGB)
         return "k95";
-    if(product == P_K70 || product == P_K70_NRGB || product == P_K70_LUX || product == P_K70_RFIRE)
+    if(product == P_K70 || product == P_K70_NRGB || product == P_K70_LUX || product == P_K70_LUX_NRGB || product == P_K70_RFIRE)
         return "k70";
     if(product == P_K65 || product == P_K65_LUX || product == P_K65_RFIRE)
         return "k65";

--- a/src/ckb-daemon/usb.h
+++ b/src/ckb-daemon/usb.h
@@ -16,15 +16,17 @@
 #define P_K65_RFIRE_STR "1b39"
 #define IS_K65(kb)      ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K65 || (kb)->product == P_K65_LUX || (kb)->product == P_K65_RFIRE))
 
-#define P_K70           0x1b13
-#define P_K70_STR       "1b13"
-#define P_K70_NRGB      0x1b09
-#define P_K70_NRGB_STR  "1b09"
-#define P_K70_LUX       0x1b33
-#define P_K70_LUX_STR   "1b33"
-#define P_K70_RFIRE     0x1b38
-#define P_K70_RFIRE_STR "1b38"
-#define IS_K70(kb)      ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70 || (kb)->product == P_K70_NRGB || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_LUX))
+#define P_K70                0x1b13
+#define P_K70_STR            "1b13"
+#define P_K70_NRGB           0x1b09
+#define P_K70_NRGB_STR       "1b09"
+#define P_K70_LUX            0x1b33
+#define P_K70_LUX_STR        "1b33"
+#define P_K70_LUX_NRGB	     0x1b36
+#define P_K70_LUX_NRGB_STR   "1b36"
+#define P_K70_RFIRE          0x1b38
+#define P_K70_RFIRE_STR      "1b38"
+#define IS_K70(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70 || (kb)->product == P_K70_NRGB || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_LUX || (kb)->product == P_K70_LUX_NRGB))
 
 #define P_K95           0x1b11
 #define P_K95_STR       "1b11"

--- a/src/ckb-daemon/usb_linux.c
+++ b/src/ckb-daemon/usb_linux.c
@@ -358,6 +358,7 @@ static _model models[] = {
     { P_K70_STR, P_K70 },
     { P_K70_NRGB_STR, P_K70_NRGB },
     { P_K70_LUX_STR, P_K70_LUX },
+    { P_K70_LUX_NRGB_STR, P_K70_LUX_NRGB },
     { P_K70_RFIRE_STR, P_K70_RFIRE },
     { P_K95_STR, P_K95 },
     { P_K95_NRGB_STR, P_K95_NRGB },

--- a/src/ckb-daemon/usb_mac.c
+++ b/src/ckb-daemon/usb_mac.c
@@ -770,7 +770,7 @@ int usbmain(){
     int vendor = V_CORSAIR;
     int products[] = {
         // Keyboards
-        P_K65, P_K65_LUX, P_K65_RFIRE, P_K70, P_K70_NRGB, P_K70_LUX, P_K70_RFIRE, P_K95, P_K95_NRGB, P_STRAFE, P_STRAFE_NRGB,
+        P_K65, P_K65_LUX, P_K65_RFIRE, P_K70, P_K70_NRGB, P_K70_LUX, P_K70_LUX_NRGB, P_K70_RFIRE, P_K95, P_K95_NRGB, P_STRAFE, P_STRAFE_NRGB,
         // Mice
         P_M65, P_M65_PRO, P_SABRE_O, P_SABRE_L, P_SABRE_N, P_SCIMITAR
     };


### PR DESCRIPTION
This is just to make the keyboard recognized by the driver. There are some issues still.