### PR TITLE
Invoke install with -m0644 for systemd/upstart

### DIFF
--- a/quickinstall
+++ b/quickinstall
@@ -136,7 +136,7 @@ if [[ $systemdc -eq 0 && `echo "$systemd" | wc -l` -ge 1 ]]; then
         sudo systemctl stop ckb-daemon >/dev/null 2>&1
         sudo mkdir -p /usr/lib/systemd/system
         checkfail $?
-        sudo install service/systemd/ckb-daemon.service /usr/lib/systemd/system 2>$TMPFILE
+        sudo install -m 0644 service/systemd/ckb-daemon.service /usr/lib/systemd/system 2>$TMPFILE
         checkfail $?
         sudo systemctl daemon-reload >/dev/null 2>&1
         sudo systemctl enable ckb-daemon 2>$TMPFILE
@@ -155,7 +155,7 @@ elif [[ $upstartc -eq 0 && `echo $upstart | wc -l` -ge 1 ]]; then
         sudo service ckb-daemon stop >/dev/null 2>&1
         sudo mkdir -p /etc/init
         checkfail $?
-        sudo install service/upstart/ckb-daemon.conf /etc/init 2>$TMPFILE
+        sudo install -m 0644 service/upstart/ckb-daemon.conf /etc/init 2>$TMPFILE
         checkfail $?
         sudo service ckb-daemon start 2>$TMPFILE
     fi


### PR DESCRIPTION
systemd unit files ought not be marked executable; doing so results in a nastygram from systemd in the logs. `install` uses mode 0744 by default. Instead, invoke `install` for upstart/systemd using -m0644.